### PR TITLE
Fix compilation issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ VERSION=$(shell git describe --always)
 BUILD_INFO=-DKGRAPH_VERSION=\"$(VERSION)\" -DKGRAPH_BUILD_ID=\"$(BUILD_ID)\" -DKGRAPH_BUILD_NUMBER=\"$(BUILD_NUMBER)\"
 CXXFLAGS+=$(BUILD_INFO) -fPIC -Wall -g -std=c++11 -I. $(OPENMP) $(OPT) $(ARCH) 
 LDFLAGS+=-static $(OPENMP)
-LDLIBS+=-lboost_timer -lboost_chrono -lboost_system -lboost_program_options -lgomp -lm -lrt
+LDLIBS+=-lboost_timer -lboost_chrono -lboost_system -lgomp -lm -lrt
 FLANN_LIBS+=-lflann_cpp_s -lflann_s
 NABO_LIBS+=-lnabo
 
@@ -52,7 +52,7 @@ release:	all
 	#tar zcf $(RELEASE).tar.gz $(RELEASE)
 
 $(PROGS) $(EXTRA_PROGS):	%:	%.cpp $(HEADERS) $(COMMON)
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $*.cpp $(COMMON) $(LDLIBS)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $*.cpp $(COMMON) $(LDLIBS) -lboost_program_options
 
 $(FLANN_PROGS):	%:	%.cpp $(HEADERS) $(COMMON)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $*.cpp $(COMMON) $(FLANN_LIBS) $(LDLIBS)

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,3 +1,4 @@
+CC = g++
 PYTHON_VERSION = 2.7
 PYTHON_INCLUDE = /usr/include/python$(PYTHON_VERSION)
 CXXFLAGS = -g -fPIC -std=c++11 -I$(PYTHON_INCLUDE) -I..
@@ -9,7 +10,7 @@ PYTHON_DIR = /usr/local/lib/python$(PYTHON_VERSION)/dist-packages/
 .PHONY:	clean install
 
 pykgraph.so:	pykgraph.cpp
-	g++ -shared -Wl,--export-dynamic -o pykgraph.so $(CXXFLAGS) pykgraph.cpp $(LDFLAGS) $(LDLIBS)
+	$(CC) -shared -Wl,--export-dynamic -o pykgraph.so $(CXXFLAGS) pykgraph.cpp $(LDFLAGS) $(LDLIBS)
 
 install:	pykgraph.so
 	mkdir -p $(PYTHON_DIR)


### PR DESCRIPTION
1. you can't override g++ for Python and Ubuntu 12.04 defaults to GCC 4.6 whereas 4.8 is needed
2. some weird issue with boost program options so I just ended up making it possible to build the python library without the progs. Here's the issue when linking against program options:

```
g++-4.8 -DKGRAPH_VERSION=\"a53dcfc\" -DKGRAPH_BUILD_ID=\"\" -DKGRAPH_BUILD_NUMBER=\"\" -fPIC -Wall -g -std=c++11 -I. -fopenmp -O3 -msse2  -static -fopenmp -o index index.cpp kgraph.o metric.o -lboost_timer -lboost_chrono -lboost_system -lboost_program_options -lgomp -lm -lrt
`.text._ZN5boost16exception_detail19error_info_injectorINS_17bad_function_callEED2Ev' referenced in section `.text._ZN5boost16exception_detail19error_info_injectorINS_17bad_function_callEED1Ev[_ZN5boost16exception_detail19error_info_injectorINS_17bad_function_callEED1Ev]' of /usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../lib/libboost_program_options.a(cmdline.o): defined in discarded section `.text._ZN5boost16exception_detail19error_info_injectorINS_17bad_function_callEED2Ev[_ZN5boost16exception_detail19error_info_injectorINS_17bad_function_callEED5Ev]' of /usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../lib/libboost_program_options.a(cmdline.o)
`.text._ZN5boost16exception_detail10clone_implINS0_19error_info_injectorINS_17bad_function_callEEEED2Ev' referenced in section `.text._ZN5boost16exception_detail10clone_implINS0_19error_info_injectorINS_17bad_function_callEEEED1Ev[_ZN5boost16exception_detail10clone_implINS0_19error_info_injectorINS_17bad_function_callEEEED1Ev]' of /usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../lib/libboost_program_options.a(cmdline.o): defined in discarded section `.text._ZN5boost16exception_detail10clone_implINS0_19error_info_injectorINS_17bad_function_callEEEED2Ev[_ZN5boost16exception_detail10clone_implINS0_19error_info_injectorINS_17bad_function_callEEEED5Ev]' of /usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../lib/libboost_program_options.a(cmdline.o)
`.text._ZN5boost16exception_detail10clone_implINS0_19error_info_injectorINS_17bad_function_callEEEED2Ev' referenced in section `.text._ZN5boost16exception_detail10clone_implINS0_19error_info_injectorINS_17bad_function_callEEEED1Ev[_ZN5boost16exception_detail10clone_implINS0_19error_info_injectorINS_17bad_function_callEEEED1Ev]' of /usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../lib/libboost_program_options.a(cmdline.o): defined in discarded section `.text._ZN5boost16exception_detail10clone_implINS0_19error_info_injectorINS_17bad_function_callEEEED2Ev[_ZN5boost16exception_detail10clone_implINS0_19error_info_injectorINS_17bad_function_callEEEED5Ev]' of /usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../lib/libboost_program_options.a(cmdline.o)
`.text._ZN5boost16exception_detail19error_info_injectorINS_15program_options16validation_errorEED2Ev' referenced in section `.text._ZN5boost16exception_detail19error_info_injectorINS_15program_options16validation_errorEED1Ev[_ZN5boost16exception_detail19error_info_injectorINS_15program_options16validation_errorEED1Ev]' of /usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../lib/libboost_program_options.a(value_semantic.o): defined in discarded section `.text._ZN5boost16exception_detail19error_info_injectorINS_15program_options16validation_errorEED2Ev[_ZN5boost16exception_detail19error_info_injectorINS_15program_options16validation_errorEED5Ev]' of /usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../lib/libboost_program_options.a(value_semantic.o)
`.text._ZN5boost16exception_detail10clone_implINS0_19error_info_injectorINS_15program_options16validation_errorEEEED2Ev' referenced in section `.text._ZN5boost16exception_detail10clone_implINS0_19error_info_injectorINS_15program_options16validation_errorEEEED1Ev[_ZN5boost16exception_detail10clone_implINS0_19error_info_injectorINS_15program_options16validation_errorEEEED1Ev]' of /usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../lib/libboost_program_options.a(value_semantic.o): defined in discarded section `.text._ZN5boost16exception_detail10clone_implINS0_19error_info_injectorINS_15program_options16validation_errorEEEED2Ev[_ZN5boost16exception_detail10clone_implINS0_19error_info_injectorINS_15program_options16validation_errorEEEED5Ev]' of /usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../lib/libboost_program_options.a(value_semantic.o)
`.text._ZN5boost16exception_detail10clone_implINS0_19error_info_injectorINS_15program_options16validation_errorEEEED2Ev' referenced in section `.text._ZN5boost16exception_detail10clone_implINS0_19error_info_injectorINS_15program_options16validation_errorEEEED1Ev[_ZN5boost16exception_detail10clone_implINS0_19error_info_injectorINS_15program_options16validation_errorEEEED1Ev]' of /usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../lib/libboost_program_options.a(value_semantic.o): defined in discarded section `.text._ZN5boost16exception_detail10clone_implINS0_19error_info_injectorINS_15program_options16validation_errorEEEED2Ev[_ZN5boost16exception_detail10clone_implINS0_19error_info_injectorINS_15program_options16validation_errorEEEED5Ev]' of /usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../lib/libboost_program_options.a(value_semantic.o)
collect2: error: ld returned 1 exit status
make: *** [index] Error 1
make: `libkgraph.so' is up to date.
```
