### PR TITLE
fixed MatrixProxy for OpenCV

### DIFF
--- a/kgraph-data.h
+++ b/kgraph-data.h
@@ -215,7 +215,7 @@ namespace kgraph {
             if (stride % A) throw invalid_argument("bad alignment");
         }
 #endif
-#ifdef __OPENCV_CORE_HPP__
+#ifdef CV_MAJOR_VERSION
         /// Construct from OpenCV matrix.
         MatrixProxy (cv::Mat const &m)
             : rows(m.rows), cols(m.cols), stride(m.step), data(m.data) {


### PR DESCRIPTION
OpenCV guards were renamed from ```__OPENCV_CORE_HPP__``` to ```OPENCV_CORE_HPP```. See OpenCV commit - https://github.com/opencv/opencv/commit/a34fbf7bb19a28863d4f1e7b2334663d61722d36#diff-114b24d27519ff9e8ece43faba55fc65L45-R46

So with fresh OpenCV (looks like starting from 3.1 or 3.2 version) you will encounter compilation error like this:

```
error: no matching function for call to ‘kgraph::MatrixProxy<unsigned char>::MatrixProxy(cv::Mat&)’
     kgraph::MatrixProxy<unsigned char> proxy(mat);
                                                 ^
In file included from ...:
/usr/local/include/kgraph-data.h:206:9: note: candidate: ‘kgraph::MatrixProxy<DATA_TYPE, A>::MatrixProxy(const kgraph::Matrix<DATA_TYPE>&) [with DATA_TYPE = unsigned char; unsigned int A = 16]’
         MatrixProxy (Matrix<DATA_TYPE> const &m)
         ^~~~~~~~~~~
/usr/local/include/kgraph-data.h:206:9: note:   no known conversion for argument 1 from ‘cv::Mat’ to ‘const kgraph::Matrix<unsigned char, 16>&’
/usr/local/include/kgraph-data.h:200:11: note: candidate: ‘constexpr kgraph::MatrixProxy<unsigned char>::MatrixProxy(const kgraph::MatrixProxy<unsigned char>&)’
     class MatrixProxy {
           ^~~~~~~~~~~
/usr/local/include/kgraph-data.h:200:11: note:   no known conversion for argument 1 from ‘cv::Mat’ to ‘const kgraph::MatrixProxy<unsigned char>&’
/usr/local/include/kgraph-data.h:200:11: note: candidate: ‘constexpr kgraph::MatrixProxy<unsigned char>::MatrixProxy(kgraph::MatrixProxy<unsigned char>&&)’
/usr/local/include/kgraph-data.h:200:11: note:   no known conversion for argument 1 from ‘cv::Mat’ to ‘kgraph::MatrixProxy<unsigned char>&&’
```

Proposed fix is to check for ```CV_MAJOR_VERSION``` instead.