### PR TITLE
Add missing return statement after module import

### DIFF
--- a/python/pykgraph.cpp
+++ b/python/pykgraph.cpp
@@ -463,7 +463,10 @@ void *
 #else
 void
 #endif
-init() { import_array(); }
+init() {
+    import_array();
+    return NULL;
+}
 
 BOOST_PYTHON_MODULE(pykgraph)
 {


### PR DESCRIPTION
When I tried to use `pykgraph` it failed with the following error:
```
RuntimeError: FATAL: module compiled as little endian, but detected different endianness at runtime
Segmentation fault (core dumped)
```

After doing a search I found the solution in https://github.com/boostorg/python/pull/218 and copied it over to `pykgraph`. 

Closes #37 